### PR TITLE
feat: bump Android SDK to v0.14.0 and bump Swift SDK to v0.12.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,6 +69,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "software.aws.solution:clickstream:0.13.0"
+    implementation "software.aws.solution:clickstream:0.14.0"
 }
 


### PR DESCRIPTION
## Description
1. bump Android SDK version to 0.14.0 and resolve the google play dependency issue.
2. bump Swift SDK version to 0.12.4 and fix crash when user attribute is empty.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
